### PR TITLE
`defaultUri` for save dialog

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,8 @@ async function saveDbmlAsSvg() {
         filters: {
             images: ['svg']
         },
-        saveLabel: 'Save SVG'
+        saveLabel: 'Save SVG',
+        defaultUri: editor.document.uri.with({ path: editor.document.uri.path.replace(/\.\w+$/, '.svg') })
     });
 
     if (uri) {


### PR DESCRIPTION
Adds a default URI for the save dialog, defaulting to the current editor's URI with the extension replaced with `.svg`. This is how most extensions work.

Thanks for this useful extension.